### PR TITLE
remove expectedFailure for green FT

### DIFF
--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -92,7 +92,6 @@ class NewVisitorTest(StaticLiveServerTestCase):
         # Satisfied, they both go back to sleep
 
 
-    @unittest.expectedFailure
     def test_layout_and_styling(self):
         # Edith goes to the home page
         self.browser.get(self.live_server_url)


### PR DESCRIPTION
We do not need to mark this functional test as expectedFailure any more.

We implemented the feature. Wooohooo!