### PR TITLE
travis build - reduce build time by not installing python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: required
 
 python:
-  - "3.5.0"
+  - "3"
 
 install:
   - pip install 'django<1.9'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 sudo: required
 
+python:
+  - "3.5"
+
 install:
   - pip install 'django<1.9'
   - pip install --upgrade selenium

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: python
 sudo: required
 
-python:
-  - "3"
-
 install:
   - pip install 'django<1.9'
   - pip install --upgrade selenium


### PR DESCRIPTION
playing around with the faint assumption that we could save time if we do not install python during our Travis CI build